### PR TITLE
Fix "headers already sent" error

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-siteworks-migration ===
 Requires at least: 5.9
-Tested up to: 6.3
+Tested up to: 6.4
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -13,6 +13,8 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.6 =
+* Fix "Headers already sent" message at end of migration
 = 1.2.5 =
 * Bug 948 - Remove regex that tried to handle { ... } conversion within <p> tags.
 * Add JavaScript to disable the Migrate button once form has been submitted

--- a/u3a-siteworks-migrate.php
+++ b/u3a-siteworks-migrate.php
@@ -83,9 +83,10 @@ function addgroups()
         $missingfile = fopen(WP_CONTENT_DIR . "/migration/missing.txt", "a") or die("Unable to open file!");
         fwrite($missingfile, $missing);
         fclose($missingfile);
-        echo ("Groups done with the following missing images and files\n" . $missing);
-    } else {
-        echo ("Groups done");
+// NT - don't echo to screen as it triggers "headers already sent" error        
+//        echo ("Groups done with the following missing images and files\n" . $missing);
+//    } else {
+//        echo ("Groups done");
     }
 }
 
@@ -138,9 +139,10 @@ function addevents()
         $missingfile = fopen(WP_CONTENT_DIR . "/migration/missing.txt", "a") or die("Unable to open file!");
         fwrite($missingfile, $missing);
         fclose($missingfile);
-        echo ("Events done with the following missing images and files\n" . $missing);
-    } else {
-        echo ("Events done");
+// NT - don't echo to screen as it triggers "headers already sent" error        
+//        echo ("Events done with the following missing images and files\n" . $missing);
+//    } else {
+//        echo ("Events done");
     }
 }
 


### PR DESCRIPTION
At the end of the migration process, the code was echoing some short messages that were a hangover from development work.
These have just been commented out.