### PR TITLE
Fix error scanning migration folder

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-siteworks-migration ===
 Requires at least: 5.9
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -13,6 +13,8 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.8 =
+* Fix error scanning for files in migration folder if filename starts with '-'
 = 1.2.7 =
 * Clarify display of admin form
 = 1.2.6 =

--- a/u3a-siteworks-migrate.php
+++ b/u3a-siteworks-migrate.php
@@ -153,9 +153,8 @@ function addotherpages()
     $logtext = "";
     $missing = "";
     //obtains array of page xml files from nongroups directory
-    $pages = scandir(WP_CONTENT_DIR . "/migration/nongroups");
-    array_splice($pages, 0, 2);
-    $num = count($pages);
+    $pages = array_diff(scandir(WP_CONTENT_DIR . "/migration/nongroups"), array('..', '.'));
+
     //code for testing a particular page
 /*     $page=new page(WP_CONTENT_DIR ."/migration/nongroups/groups.xml","page","");
          $page->process("");
@@ -163,17 +162,17 @@ function addotherpages()
         echo("done");
         exit; */
 
-    for ($i = 0; $i < $num; $i++) {
-        $page = new page(WP_CONTENT_DIR . "/migration/nongroups/" . $pages[$i], "page", "");
-        error_log("processing other page: ". $pages[$i]);
+    foreach ($pages as $currentPage) {
+        error_log("processing other page: ". $currentPage);
+        $page = new page(WP_CONTENT_DIR . "/migration/nongroups/" . $currentPage, "page", "");
         $page->process("");
         $page->addpage();
         if (!empty($page->logtext)) {
-            $logtext .= "Error in " . $pages[$i] . "\n. Details " . $page->logtext . "\n";
+            $logtext .= "Error in " . $currentPage . "\n. Details " . $page->logtext . "\n";
         }
-        $logtext .= $pages[$i] . " processed\n";
+        $logtext .= $currentPage . " processed\n";
         if (!empty($page->missing)) {
-            $missing .= "Missing files on page " . $pages[$i] . $page->missing . "\n";
+            $missing .= "Missing files on page " . $currentPage . $page->missing . "\n";
         }
     }
     u3a_migration_notices();

--- a/u3a-siteworks-migration.php
+++ b/u3a-siteworks-migration.php
@@ -3,7 +3,7 @@
 Plugin Name: u3a Siteworks Migration 
 Plugin URI: https://u3awpdev.org.uk/
 Description: Provides facility to migrate html files from sitebuilder
-Version: 1.2.7
+Version: 1.2.8
 Author: Camilla Jordan, Nick Talbott, u3aWPdev team
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Before this fix, an xml file with a filename starting with a '-' (or indeed a filename starting with a punctuation character that sorts alphabetically before '.') would be incorrectly handled causing the import process to crash.  This has not cropped up before as export filenames typically start with an alphabetic character.