### PR TITLE
Correct missing file reporting in groups

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.9 =
+* Fix issue reporting missing group files in the "Missing files" document.
 = 1.2.8 =
 * Fix error scanning for files in migration folder if filename starts with '-'
 = 1.2.7 =

--- a/u3a-siteworks-agroup.php
+++ b/u3a-siteworks-agroup.php
@@ -140,9 +140,8 @@ class agroup
             //file not found so use defaults and message added to $missing
             $groupcontent = "";
             $this->email = "";
-            $notfound = "xml file for " . sanitize_text_field($this->name) . " not found\n";
+            $notfound = "xml group page file for " . sanitize_text_field($this->name) . " not found\n";
             $this->missing .= $notfound;
-            //echo("xml file for ".sanitize_text_field($this->name)." not found\n");
         }
 
         $groupcontent = preparetoadd($groupcontent);

--- a/u3a-siteworks-migrate.php
+++ b/u3a-siteworks-migrate.php
@@ -68,8 +68,8 @@ function addgroups()
         $thisgroup = new agroup($name, $day, $time, $frequency, $status, $file, $pg, $fname);
         $thisgroup->addcontact($contactname, $contactemail);
         $thisgroup->addgroup();
-        if (!empty($missing . $thisgroup->missing)) {
-            $missing .= "Missing files in " . $name . "pages " . $thisgroup->missing;
+        if (!empty($thisgroup->missing)) {
+            $missing .= "Missing files in " . $name . " - " . $thisgroup->missing;
         }
 
         if (!empty($thisgroup->logtext)) {

--- a/u3a-siteworks-migration.php
+++ b/u3a-siteworks-migration.php
@@ -3,7 +3,7 @@
 Plugin Name: u3a Siteworks Migration 
 Plugin URI: https://u3awpdev.org.uk/
 Description: Provides facility to migrate html files from sitebuilder
-Version: 1.2.8
+Version: 1.2.9
 Author: Camilla Jordan, Nick Talbott, u3aWPdev team
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/u3a-siteworks-page.php
+++ b/u3a-siteworks-page.php
@@ -153,7 +153,7 @@ class page
                         $image = new media($img, $caption, $details);
                         $picid = $image->importmedia($details);
                         if ($picid == -1) {
-                            $this->missing .= "(Missing image" . $img . ")\n";
+                            $this->missing .= "(Missing image: " . $img . ")\n";
                         } else {
                             $imgstr = $image->filename;
                             $imgref = $this->preurl . $imgstr;


### PR DESCRIPTION
Provide clearer error reporting when group xml pages are not found and correct erroneous inclusion of some content in the report.