### PR TITLE
Scan zip file on upload for fname bug

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.10 =
+* Scans zip file on upload to check <fname> content for misplaced tags (Site Builder export bug)
 = 1.2.9 =
 * Fix issue reporting missing group files in the "Missing files" document.
 = 1.2.8 =

--- a/u3a-siteworks-migration.php
+++ b/u3a-siteworks-migration.php
@@ -3,7 +3,7 @@
 Plugin Name: u3a Siteworks Migration 
 Plugin URI: https://u3awpdev.org.uk/
 Description: Provides facility to migrate html files from sitebuilder
-Version: 1.2.9
+Version: 1.2.10
 Author: Camilla Jordan, Nick Talbott, u3aWPdev team
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
There is an occasional bug with Site Builder export files wrongly handling markup within <fname> sections.  Apparently it's not possible to fix this in the export process, and importing from files with this bug causes the import process to crash.  This change scans the zip file on upload and warns if this bug is present in the files allowing manual correction before continuing.