### PR TITLE
1031 Media title set to caption instead of filename

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,9 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.11 =
+* When importing Media, set the Title to the caption instead of the filename.
+* Do not replace spaces with hyphens in the media caption
 = 1.2.10 =
 * Scans zip file on upload to check <fname> content for misplaced tags (Site Builder export bug)
 = 1.2.9 =

--- a/u3a-siteworks-media.php
+++ b/u3a-siteworks-media.php
@@ -138,7 +138,7 @@ class media
     }
 
 
-    $this->caption = str_replace(" ", "-", $this->caption);
+    //NT not required. $this->caption = str_replace(" ", "-", $this->caption);
 
     $fileFound = false;
     if ($this->img_source_URL && $this->UR_exists($this->img)) $fileFound = true;
@@ -160,7 +160,7 @@ class media
       $wp_filetype = wp_check_filetype($this->filename, null);
       $attachment = array(
         'post_mime_type' => $wp_filetype['type'],
-        'post_title' => sanitize_file_name($this->filename),
+        'post_title' => sanitize_text_field($this->caption),
         'post_excerpt' => sanitize_text_field($this->caption),
         'post_content' => sanitize_text_field($details),
         'post_status' => 'inherit'

--- a/u3a-siteworks-migration.php
+++ b/u3a-siteworks-migration.php
@@ -3,7 +3,7 @@
 Plugin Name: u3a Siteworks Migration 
 Plugin URI: https://u3awpdev.org.uk/
 Description: Provides facility to migrate html files from sitebuilder
-Version: 1.2.10
+Version: 1.2.11
 Author: Camilla Jordan, Nick Talbott, u3aWPdev team
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Bug 1031 The Media Title field should be populated from the caption instead of the filename.
Change proposed on forum.  