### PR TITLE
Only show Missing Files link if there is content to show

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.13 =
+* When migration is complete, only show link to Missing Files if there is content to show
 = 1.2.12 =
 * Scans zip file on upload to check <contact> content for misplaced tags (Site Builder export bug)
 = 1.2.11 =

--- a/u3a-siteworks-migration-admin.php
+++ b/u3a-siteworks-migration-admin.php
@@ -25,11 +25,18 @@ function u3a_show_migrate_menu()
     if ($status == "1") {
         $missing_link = content_url('/migration/missing.txt');
         $log_link = content_url('/migration/migrationlog.txt');
+        // only show missing files link if the file has content
+        $missingFileSize = filesize(WP_CONTENT_DIR . "/migration/missing.txt");
+        if ($missingFileSize > 0) {
+            $missingText = '<a href="' . $missing_link . '" target="_blank">Missing files</a>';
+        } else {
+            $missingText = 'No missing files';
+        }
         $status_text = <<< END
         <div class="notice notice-error is-dismissible inline">
-        <p>Migration Completed &nbsp; - &nbsp; 
+        <p><b>Migration Completed</b> &nbsp; - &nbsp; 
         <a href="$log_link" target="_blank">Migration log</a> &nbsp;
-        <a href="$missing_link" target="_blank">Missing files</a>
+        $missingText
         </p></div>
 END;
     }

--- a/u3a-siteworks-migration.php
+++ b/u3a-siteworks-migration.php
@@ -3,7 +3,7 @@
 Plugin Name: u3a Siteworks Migration 
 Plugin URI: https://u3awpdev.org.uk/
 Description: Provides facility to migrate html files from sitebuilder
-Version: 1.2.12
+Version: 1.2.13
 Author: Camilla Jordan, Nick Talbott, u3aWPdev team
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
After migration is complete, only display a link to show missing files if there is actually some content to show.