### PR TITLE
add check for STX character in xml files

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,8 @@ Site Builder import
 Imports Site Builder XML files into a WordPress site which has the SiteWorks core plugin installed
 
 == Changelog ==
+= 1.2.14 =
+* Add check for STX character (0x02) in files on zip file upload.
 = 1.2.13 =
 * When migration is complete, only show link to Missing Files if there is content to show
 = 1.2.12 =

--- a/u3a-siteworks-migration-admin.php
+++ b/u3a-siteworks-migration-admin.php
@@ -218,6 +218,40 @@ function u3a_upload_migration_zip()
         }
     }
 
+    // Check for STX character in xml files 
+
+    foreach (glob($migrationFolder . '/allgroups/*.xml') as $xmlfile) {
+        $contents = file($xmlfile);
+        $lc = 1;
+        foreach ($contents as $line) {
+            if (strstr($line, chr(2))) {
+                $fnameErrors[] = $xmlfile;
+                $fnameErrors[] = "STX found in line $lc";
+            }
+            $lc++;
+        }
+    }
+    foreach (glob($migrationFolder . '/nongroups/*.xml') as $xmlfile) {
+        $contents = file($xmlfile);
+        $lc = 1;
+        foreach ($contents as $line) {
+            if (strstr($line, chr(2))) {
+                $fnameErrors[] = $xmlfile;
+                $fnameErrors[] = "STX found in line $lc";
+            }
+            $lc++;
+        }
+    }
+    $xmlfile = $migrationFolder . '/eventlist.xml';
+    $contents = file($xmlfile);
+    $lc = 1;
+    foreach ($contents as $line) {
+        if (strstr($line, chr(2))) {
+            $fnameErrors[] = $xmlfile;
+            $fnameErrors[] = "STX found in line $lc";
+        }
+        $lc++;
+    }
 
     // If we have errors, save as transient and set status value
     if (count($fnameErrors)) {

--- a/u3a-siteworks-migration.php
+++ b/u3a-siteworks-migration.php
@@ -3,7 +3,7 @@
 Plugin Name: u3a Siteworks Migration 
 Plugin URI: https://u3awpdev.org.uk/
 Description: Provides facility to migrate html files from sitebuilder
-Version: 1.2.13
+Version: 1.2.14
 Author: Camilla Jordan, Nick Talbott, u3aWPdev team
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Some Site Builder export files contain STX control character which results in invalid XML and breaks processing.  This change detects the presence of an STX character, allowing for manual correction of the file(s) before proceeding with the migration.